### PR TITLE
updating slave dockerfile to use newer pip and python3

### DIFF
--- a/docker/openstack-jenkins-slave/Dockerfile
+++ b/docker/openstack-jenkins-slave/Dockerfile
@@ -6,9 +6,10 @@ RUN yum-config-manager --enable rhel-7-server-rpms > /dev/null --enable rhel-7-s
 
 RUN yum install python-devel gcc ansible wget -y
 RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && chmod 700 epel-release-latest-7.noarch.rpm && rpm -i epel-release-latest-7.noarch.rpm
-RUN rm -fr /var/cache/yum/*
+
 RUN yum clean all
-RUN yum update
+RUN rm -fr /var/cache/yum/*
+
 RUN yum install python36 python36-setuptools -y && easy_install-3.6 pip && pip install --upgrade pip
 RUN pip install python-openstackclient
 RUN pip install python-heatclient

--- a/docker/openstack-jenkins-slave/Dockerfile
+++ b/docker/openstack-jenkins-slave/Dockerfile
@@ -10,9 +10,10 @@ RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm 
 RUN rm -fr /var/cache/yum/*
 RUN yum clean all
 
-RUN yum install python36 python36-setuptools -y && easy_install-3.6 pip && pip install --upgrade pip
+RUN yum install python36 python36-setuptools -y
 
-RUN cd /root && pip install python-openstackclient python-heatclient
+RUN cd /root && easy_install-3.6 pip && pip install --upgrade pip
+RUN pip install python-openstackclient python-heatclient
 
 RUN cd /home/jenkins
 

--- a/docker/openstack-jenkins-slave/Dockerfile
+++ b/docker/openstack-jenkins-slave/Dockerfile
@@ -6,15 +6,7 @@ RUN yum-config-manager --enable rhel-7-server-rpms > /dev/null --enable rhel-7-s
 
 RUN yum install python-devel gcc ansible wget -y
 RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && chmod 700 epel-release-latest-7.noarch.rpm && rpm -i epel-release-latest-7.noarch.rpm
-
-RUN rm -fr /var/cache/yum/*
-RUN yum clean all
-
-RUN yum install python36 python36-setuptools -y
-
-RUN cd /root && easy_install-3.6 pip && pip install --upgrade pip
+RUN yum install python36 python36-setuptools -y && easy_install-3.6 pip && pip install --upgrade pip
 RUN pip install python-openstackclient python-heatclient
-
-RUN cd /home/jenkins
 
 USER 1001

--- a/docker/openstack-jenkins-slave/Dockerfile
+++ b/docker/openstack-jenkins-slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.9.51
+FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:latest
 
 USER root
 
@@ -6,6 +6,9 @@ RUN yum-config-manager --enable rhel-7-server-rpms > /dev/null --enable rhel-7-s
 
 RUN yum install python-devel gcc ansible wget -y
 RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && chmod 700 epel-release-latest-7.noarch.rpm && rpm -i epel-release-latest-7.noarch.rpm
+RUN rm -fr /var/cache/yum/*
+RUN yum clean all
+RUN yum update
 RUN yum install python36 python36-setuptools -y && easy_install-3.6 pip && pip install --upgrade pip
 RUN pip install python-openstackclient
 RUN pip install python-heatclient

--- a/docker/openstack-jenkins-slave/Dockerfile
+++ b/docker/openstack-jenkins-slave/Dockerfile
@@ -2,13 +2,12 @@ FROM registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.9.51
 
 USER root
 
-RUN yum-config-manager --enable rhel-7-server-rpms > /dev/null --enable rhel-7-server-extras-rpms > /dev/null 
+RUN yum-config-manager --enable rhel-7-server-rpms > /dev/null --enable rhel-7-server-extras-rpms > /dev/null
 
-RUN yum install python-devel gcc ansible -y
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && python get-pip.py && pip install pip==9.0.3
-RUN pip install python-openstackclient 
+RUN yum install python-devel gcc ansible wget -y
+RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && chmod 700 epel-release-latest-7.noarch.rpm && rpm -i epel-release-latest-7.noarch.rpm
+RUN yum install python36 python36-setuptools -y && easy_install-3.6 pip && pip install --upgrade pip
+RUN pip install python-openstackclient
 RUN pip install python-heatclient
 
 USER 1001
-
-## Pip version is hardcoded to 9.0.3 as with pip versions 10 and 18 openstack clients install fails

--- a/docker/openstack-jenkins-slave/Dockerfile
+++ b/docker/openstack-jenkins-slave/Dockerfile
@@ -7,11 +7,13 @@ RUN yum-config-manager --enable rhel-7-server-rpms > /dev/null --enable rhel-7-s
 RUN yum install python-devel gcc ansible wget -y
 RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && chmod 700 epel-release-latest-7.noarch.rpm && rpm -i epel-release-latest-7.noarch.rpm
 
-RUN yum clean all
 RUN rm -fr /var/cache/yum/*
+RUN yum clean all
 
 RUN yum install python36 python36-setuptools -y && easy_install-3.6 pip && pip install --upgrade pip
-RUN pip install python-openstackclient
-RUN pip install python-heatclient
+
+RUN cd /root && pip install python-openstackclient python-heatclient
+
+RUN cd /home/jenkins
 
 USER 1001


### PR DESCRIPTION
Seems to build OK, and removed the pinning of pip versions etc. Also removes the soon to be deprecated python 2.x packages.